### PR TITLE
[Feat] Identify elements + other fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "homepage": "https://github.com/slurmulon/juke#readme",
   "dependencies": {
     "howler": "^2.0.4",
-    "stateful-dynamic-interval": "github:slurmulon/stateful-dynamic-interval"
+    "stateful-dynamic-interval": "github:slurmulon/stateful-dynamic-interval",
+    "teoria": "^2.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/src/elements.js
+++ b/src/elements.js
@@ -1,3 +1,5 @@
+import teoria from 'teoria'
+
 /**
  * Represents a single playable element (Note, Scale, Chord or Rest)
  */
@@ -12,12 +14,40 @@ export class Element {
   }
 
   get inputs () {
+    console.log('input atom', this.data.atom)
     return this.data.atom.init['arguments']
   }
 
-  // FIXME: support implicit elements (involves reflecting on the value - can use teoria for this, most likely)
   get kind () {
-    return this.data.atom.keyword
+    const explicits = ['Note', 'Scale', 'Chord', 'Rest']
+    const keyword = this.data.atom.keyword
+
+    if (explicits.includes(keyword)) {
+      return keyword.toLowerCase()
+    }
+
+    return this.identify()
+  }
+
+  identify () {
+    let identity
+
+    try {
+      teoria.note(this.value)
+      identity = 'note'
+    } catch (e) {}
+
+    try {
+      teoria.scale(this.value)
+      identity = 'scale'
+    } catch (e) {}
+
+    try {
+      teoria.chord(this.value)
+      identity = 'chord'
+    } catch (e) {}
+
+    return identity
   }
 
 }
@@ -34,7 +64,7 @@ export class Beat {
   }
 
   get duration () {
-    return !this.empty ? this.data.duration : 1
+    return !this.empty ? this.data.duration : 1 // TODO: need to think about using 1 as fallback more
   }
 
   get items () {
@@ -55,7 +85,7 @@ export class Beat {
   }
 
   static from (beats) {
-    if (beats instanceof Array) {
+    if (beats instanceof Array) { // in other words, a measure
       return beats.map(beat => new Beat(beat))
     }
 
@@ -63,15 +93,3 @@ export class Beat {
   }
 
 }
-
-// export class Measure {
-
-//   constructor (data) {
-//     this.data = data
-//   }
-
-//   get items () {
-//     return this.data.map(Beat.from)
-//   }
-
-// }

--- a/src/elements.js
+++ b/src/elements.js
@@ -14,7 +14,6 @@ export class Element {
   }
 
   get inputs () {
-    console.log('input atom', this.data.atom)
     return this.data.atom.init['arguments']
   }
 
@@ -35,17 +34,17 @@ export class Element {
     try {
       teoria.note(this.value)
       identity = 'note'
-    } catch (e) {}
+    } catch (_) {}
 
     try {
       teoria.scale(this.value)
       identity = 'scale'
-    } catch (e) {}
+    } catch (_) {}
 
     try {
       teoria.chord(this.value)
       identity = 'chord'
-    } catch (e) {}
+    } catch (_) {}
 
     return identity
   }
@@ -64,7 +63,7 @@ export class Beat {
   }
 
   get duration () {
-    return !this.empty ? this.data.duration : 1 // TODO: need to think about using 1 as fallback more
+    return !this.empty ? this.data.duration : 0 // TODO: need to think about using 1 as fallback more
   }
 
   get items () {

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
 export * from './track'
+export * from './elements'

--- a/src/track.js
+++ b/src/track.js
@@ -129,6 +129,8 @@ export class Track {
     const wait  = this.interval
     const duration = wait * beat.duration
 
+    console.log('[juke] step duration', beat, duration)
+
     if (start instanceof Function) {
       start(beat)
     }

--- a/src/track.js
+++ b/src/track.js
@@ -120,25 +120,14 @@ export class Track {
   /**
    * The action to perform on next interval
    */
-  // FIXME: this has a bug where if the duration is 0 it still ends up waiting
-  // - I believe this is based on lack of use of `interval`
-  // FIXME: when paused on elements with a duration greater than the default interval
-  //        then pause and resume doesn't work, it ends up playing the empty beat
-  //        for the default interval instead of 0 (diverges from beat)
-  //        - I think this might be happening because when we resume, the `step` function is run again, which ends up bumping the next tick!!!!!
   step (interval) {
-    console.log('[juke] ~~~~~~~~~~~~~~~~~~~~~~~~~ stepping (interval)!', interval)
-
     const beat  = this.state.beat
     const next  = this.next.bind(this)
     const play  = this.on.step.play
     const start = this.on.step.start
     const stop  = this.on.step.stop
     const wait  = this.interval
-    // const wait  = (interval && interval.wait >= 0) ? interval.wait : this.interval
     const duration = wait * beat.duration
-
-    console.log('[juke] step duration (interval, beat, wait, duration)', interval, beat, wait, duration)
 
     if (start instanceof Function) {
       start(beat)
@@ -160,8 +149,6 @@ export class Track {
 
     //   // next()
     // }, duration)
-
-    console.log('[juke] step, about to bump next (next duration)', duration)
 
     // TODO: this is an alternative impl. it avoids timing issues but
     // it prematurely bumps the cursor, before `stop` is called

--- a/test/elements-spec.js
+++ b/test/elements-spec.js
@@ -1,0 +1,72 @@
+import chai from 'chai'
+import chaiThings from 'chai-things'
+import fs from 'fs'
+import { Element, Beat } from '../dist/bundle'
+import fixtures from './fixtures'
+
+const should = chai.should()
+
+chai.use(chaiThings)
+
+describe('Element', () => {
+  describe('value', () => {
+    it('should return the first input of the element instance/atom', () => {
+      const data = fixtures.slow.json
+      const elem = new Element(data)
+
+      elem.value.should.equal(elem.inputs[0])
+    })
+  })
+
+  describe('inputs', () => {
+    it('should return the arguments object of the element instance/atom', () => {
+
+    })
+  })
+
+  describe('kind', () => {
+    describe('explicit', () => {
+
+    })
+
+    describe('implicit', () => {
+
+    })
+  })
+
+  describe('identify', () => {
+    describe('note', () => {
+
+    })
+
+    describe('scale', () => {
+
+    })
+
+    describe('chord', () => {
+
+    })
+  })
+})
+
+describe('Beat', () => {
+  describe('duration', () => {
+
+  })
+
+  describe('items', () => {
+
+  })
+
+  describe('empty', () => {
+
+  })
+
+  describe('exists', () => {
+
+  })
+
+  describe('from', () => {
+
+  })
+})

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,0 +1,8 @@
+import fs from 'fs'
+
+export default {
+  slow: {
+    json  : JSON.parse(fs.readFileSync('./test/fixtures/slow.warb.json')),
+    audio : fs.readFileSync('./test/fixtures/slow.wav')
+  }
+}

--- a/test/track-spec.js
+++ b/test/track-spec.js
@@ -2,59 +2,65 @@ import chai from 'chai'
 import chaiThings from 'chai-things'
 import fs from 'fs'
 import { Track } from '../dist/bundle'
+import fixtures from './fixtures'
 
-chai.should()
+const should = chai.should()
+
 chai.use(chaiThings)
 
-const fixtures = {
-  slow: {
-    json  : JSON.parse(fs.readFileSync('./test/fixtures/slow.warb.json')),
-    audio : fs.readFileSync('./test/fixtures/slow.wav')
-  }
-}
+// const fixtures = {
+//   slow: {
+//     json  : JSON.parse(fs.readFileSync('./test/fixtures/slow.warb.json')),
+//     audio : fs.readFileSync('./test/fixtures/slow.wav')
+//   }
+// }
 
 describe('Track', () => {
   // FIXME: this is failing because setInterval doesn't kick off UNTIl 2000 ms, not starts and then waits until 2000 ms.
   describe('step', () => {
-    it('should play the current beat', (done) => {
-      const source = fixtures.slow.json //JSON.parse(fs.readFileSync('./test/fixtures/slow.warb.json'))
-      const audio  = fixtures.slow.audio //fs.readFileSync('./test/fixtures/slow.wav')
+    it('should play the current beat', done => {
+      const source = fixtures.slow.json
+      const audio  = fixtures.slow.audio
       const track  = new Track({ source, audio })
+      const wait   = source.headers['ms-per-beat']
       let passes   = false
 
-      track.on.step.stop = beat => passes = true
+      track.on.step.stop = beat => {
+        passes = true
+      }
 
       track.start()
 
       setTimeout(() => {
         passes.should.equal(true)
-        console.log('playing should end!')
         done()
-      }, 2000)
+      }, wait + 5)
     }).timeout(0)
 
     it('should wait ms-per-beat between each step', () => {
 
     })
 
-    it('should recursively step through the track\'s measures and beats', (done) => {
+    it.only('should recursively step through the track\'s measures and beats', done => {
       const source = fixtures.slow.json
       const audio  = fixtures.slow.audio
-      const track  = new Track({ source, audio })
+      const track  = new Track({ source, audio, tempo: 140 })
       const limit  = track.data.length * track.data[0].length
 
       let steps  = 0
       let passes = false
 
-      track.on.step.play = beat => {
-        console.log('stepped through beat', beat)
+      track.on.step.start = beat => {
+        console.log('stepped through beat', beat.data)
         console.log('steps taken so far', steps)
 
         steps++
       }
 
       track.on.step.stop = beat => {
+        console.log('!!!! stopping (steps, limit)', steps, limit, beat)
         if (beat && steps === limit) {
+          console.log('ABOUT TO EVALUATE BROOOOO')
           true.should.equal(true)
           done()
         }

--- a/test/track-spec.js
+++ b/test/track-spec.js
@@ -44,7 +44,7 @@ describe('Track', () => {
     it.only('should recursively step through the track\'s measures and beats', done => {
       const source = fixtures.slow.json
       const audio  = fixtures.slow.audio
-      const track  = new Track({ source, audio, tempo: 140 })
+      const track  = new Track({ source, audio, tempo: 240 })
       const limit  = track.data.length * track.data[0].length
 
       let steps  = 0
@@ -58,9 +58,7 @@ describe('Track', () => {
       }
 
       track.on.step.stop = beat => {
-        console.log('!!!! stopping (steps, limit)', steps, limit, beat)
         if (beat && steps === limit) {
-          console.log('ABOUT TO EVALUATE BROOOOO')
           true.should.equal(true)
           done()
         }


### PR DESCRIPTION
- :art: Parsing of Warble's `#` operator (implicit element). Identifies which element type based on the content ("reflection")
- :bug: Fixed default duration of beat
- :bug: Fixed default interval value based on tempo (divide instead of multiply)
- :bug: Fixes and experimentation around Track.step (primarily towards the pause/resume bug) 